### PR TITLE
Add type mapping annotation and fix createIndex() method failure

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.extension.siddhi.store.elasticsearch</groupId>
         <artifactId>siddhi-store-elasticsearch-parent</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>siddhi-store-elasticsearch</artifactId>

--- a/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/ElasticsearchEventTable.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/ElasticsearchEventTable.java
@@ -109,8 +109,6 @@ import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchT
 import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.
         ANNOTATION_ELEMENT_INDEX_NUMBER_OF_SHARDS;
 import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.
-        ANNOTATION_ELEMENT_INDEX_TYPE;
-import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.
         ANNOTATION_ELEMENT_MEMBER_LIST;
 import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.
         ANNOTATION_ELEMENT_PASSWORD;
@@ -140,7 +138,6 @@ import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchT
         DEFAULT_CONCURRENT_REQUESTS;
 import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.DEFAULT_FLUSH_INTERVAL;
 import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.DEFAULT_HOSTNAME;
-import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.DEFAULT_INDEX_TYPE;
 import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.DEFAULT_IO_THREAD_COUNT;
 import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.
         DEFAULT_NUMBER_OF_REPLICAS;
@@ -198,9 +195,6 @@ import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchT
                         description = "The name of the Elasticsearch index.",
                         type = {DataType.STRING}, optional = true,
                         defaultValue = "The table name defined in the Siddhi App query."),
-                @Parameter(name = "index.type",
-                        description = "The the type of the index.",
-                        type = {DataType.STRING}, optional = true, defaultValue = "null"),
                 @Parameter(name = "payload.index.of.index.name",
                         description = "The payload which is used to create the index. This can be used if the user " +
                                 "needs to create index names dynamically",
@@ -312,7 +306,6 @@ public class ElasticsearchEventTable extends AbstractRecordTable {
     private List<String> primaryKeys;
     private String hostname = DEFAULT_HOSTNAME;
     private String indexName;
-    private String indexType = DEFAULT_INDEX_TYPE;
     private String indexAlias;
     private int port = DEFAULT_PORT;
     private String scheme = DEFAULT_SCHEME;
@@ -369,7 +362,6 @@ public class ElasticsearchEventTable extends AbstractRecordTable {
             } else {
                 port = Integer.parseInt(configReader.readConfig(ANNOTATION_ELEMENT_HOSTNAME, String.valueOf(port)));
             }
-            indexType = storeAnnotation.getElement(ANNOTATION_ELEMENT_INDEX_TYPE);
             if (!ElasticsearchTableUtils.isEmpty(storeAnnotation.
                     getElement(ANNOTATION_ELEMENT_INDEX_NUMBER_OF_SHARDS))) {
                 numberOfShards = Integer.parseInt(storeAnnotation.getElement(
@@ -657,11 +649,7 @@ public class ElasticsearchEventTable extends AbstractRecordTable {
             compiledCondition) throws ElasticsearchServiceException {
         String condition = ElasticsearchTableUtils.resolveCondition((ElasticsearchCompiledCondition) compiledCondition,
                 findConditionParameterMap);
-        if (indexType != null) {
-            return new ElasticsearchRecordIterator(indexName, condition, restHighLevelClient, attributes);
-        } else {
-            return new ElasticsearchRecordIterator(indexName, indexType, condition, restHighLevelClient, attributes);
-        }
+        return new ElasticsearchRecordIterator(indexName, condition, restHighLevelClient, attributes);
     }
 
     /**.
@@ -868,9 +856,6 @@ public class ElasticsearchEventTable extends AbstractRecordTable {
             XContentBuilder builder = XContentFactory.jsonBuilder();
             builder.startObject();
             {
-                if (indexType != null) {
-                    builder.startObject(indexType);
-                }
                 builder.startObject(MAPPING_PROPERTIES_ELEMENT);
                 {
                     for (Attribute attribute : attributes) {
@@ -908,9 +893,6 @@ public class ElasticsearchEventTable extends AbstractRecordTable {
                     }
                 }
                 builder.endObject();
-                if (indexType != null) {
-                    builder.endObject();
-                }
             }
             builder.endObject();
             request.mapping(builder);

--- a/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/ElasticsearchEventTable.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/ElasticsearchEventTable.java
@@ -200,7 +200,7 @@ import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchT
                         defaultValue = "The table name defined in the Siddhi App query."),
                 @Parameter(name = "index.type",
                         description = "The the type of the index.",
-                        type = {DataType.STRING}, optional = true, defaultValue = "empty"),
+                        type = {DataType.STRING}, optional = true, defaultValue = "null"),
                 @Parameter(name = "payload.index.of.index.name",
                         description = "The payload which is used to create the index. This can be used if the user " +
                                 "needs to create index names dynamically",

--- a/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/ElasticsearchEventTable.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/ElasticsearchEventTable.java
@@ -492,7 +492,7 @@ public class ElasticsearchEventTable extends AbstractRecordTable {
                 listOfHostnames = storeAnnotation.getElement(ANNOTATION_ELEMENT_MEMBER_LIST);
             }
 
-            List<Annotation> typeMappingsAnnotations = storeAnnotation.getAnnotations("TypeMappings");
+            List<Annotation> typeMappingsAnnotations = storeAnnotation.getAnnotations(ANNOTATION_TYPE_MAPPINGS);
             if (typeMappingsAnnotations.size() > 0) {
                 for (Element element : typeMappingsAnnotations.get(0).getElements()) {
                     validateTypeMappingAttribute(element.getKey());
@@ -910,7 +910,7 @@ public class ElasticsearchEventTable extends AbstractRecordTable {
             throw new ElasticsearchEventTableException("Error while creating indices for table id : '" +
                     tableDefinition.getId(), e);
         } catch (ElasticsearchStatusException e) {
-            logger.debug("Elasticsearch status exception occurs while creating index for table id: " +
+            logger.error("Elasticsearch status exception occurs while creating index for table id: " +
                     tableDefinition.getId(), e);
         }
     }

--- a/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/ElasticsearchRecordIterator.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/ElasticsearchRecordIterator.java
@@ -44,25 +44,6 @@ public class ElasticsearchRecordIterator implements RecordIterator<Object[]> {
     private List<Attribute> attributes;
     private Iterator<SearchHit> elasticsearchHitsIterator;
 
-    public ElasticsearchRecordIterator(String indexName, String indexType, String queryString, 
-                                       RestHighLevelClient restHighLevelClient, List<Attribute> attributes)
-            throws ElasticsearchServiceException {
-        this.attributes = attributes;
-        QueryBuilder queryBuilder = getQueryBuilder(queryString);
-        SearchRequest searchRequest = new SearchRequest(indexName);
-        searchRequest.types(indexType);
-        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-        searchSourceBuilder.query(queryBuilder);
-        searchRequest.source(searchSourceBuilder);
-        try {
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, RequestOptions.DEFAULT);
-            elasticsearchHitsIterator = searchResponse.getHits().iterator();
-        } catch (IOException e) {
-            throw new ElasticsearchServiceException("Error while performing search the query: '" + queryString + "'",
-                    e);
-        }
-    }
-
     public ElasticsearchRecordIterator(String indexName, String queryString,
                                        RestHighLevelClient restHighLevelClient, List<Attribute> attributes)
             throws ElasticsearchServiceException {

--- a/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/ElasticsearchRecordIterator.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/ElasticsearchRecordIterator.java
@@ -63,6 +63,24 @@ public class ElasticsearchRecordIterator implements RecordIterator<Object[]> {
         }
     }
 
+    public ElasticsearchRecordIterator(String indexName, String queryString,
+                                       RestHighLevelClient restHighLevelClient, List<Attribute> attributes)
+            throws ElasticsearchServiceException {
+        this.attributes = attributes;
+        QueryBuilder queryBuilder = getQueryBuilder(queryString);
+        SearchRequest searchRequest = new SearchRequest(indexName);
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        searchSourceBuilder.query(queryBuilder);
+        searchRequest.source(searchSourceBuilder);
+        try {
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, RequestOptions.DEFAULT);
+            elasticsearchHitsIterator = searchResponse.getHits().iterator();
+        } catch (IOException e) {
+            throw new ElasticsearchServiceException("Error while performing search the query: '" + queryString + "'",
+                    e);
+        }
+    }
+
     @Override
     public void close() throws IOException {
     }

--- a/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/utils/ElasticsearchTableConstants.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/utils/ElasticsearchTableConstants.java
@@ -47,6 +47,7 @@ public class ElasticsearchTableConstants {
     public static final String ANNOTATION_ELEMENT_TRUSRTSTORE_PASS = "trust.store.pass";
     public static final String ANNOTATION_ELEMENT_PAYLOAD_INDEX_OF_INDEX_NAME = "payload.index.of.index.name";
     public static final String ANNOTATION_ELEMENT_MEMBER_LIST = "elasticsearch.member.list";
+    public static final String ANNOTATION_TYPE_MAPPINGS = "TypeMappings";
 
     public static final String DEFAULT_HOSTNAME = "localhost";
     public static final String DEFAULT_INDEX_TYPE = "_doc";

--- a/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/utils/ElasticsearchTableConstants.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/utils/ElasticsearchTableConstants.java
@@ -32,7 +32,6 @@ public class ElasticsearchTableConstants {
     public static final String ANNOTATION_ELEMENT_INDEX_NUMBER_OF_SHARDS = "index.number.of.shards";
     public static final String ANNOTATION_ELEMENT_INDEX_NUMBER_OF_REPLICAS = "index.number.of.replicas";
     public static final String ANNOTATION_ELEMENT_INDEX_ALIAS = "index.alias";
-    public static final String ANNOTATION_ELEMENT_INDEX_TYPE = "index.type";
     public static final String ANNOTATION_ELEMENT_UPDATE_BATCH_SIZE = "update.batch.size";
     public static final String ANNOTATION_ELEMENT_BULK_ACTIONS = "bulk.actions";
     public static final String ANNOTATION_ELEMENT_BULK_SIZE = "bulk.size";
@@ -50,7 +49,6 @@ public class ElasticsearchTableConstants {
     public static final String ANNOTATION_TYPE_MAPPINGS = "TypeMappings";
 
     public static final String DEFAULT_HOSTNAME = "localhost";
-    public static final String DEFAULT_INDEX_TYPE = "_doc";
     public static final int DEFAULT_PORT = 9200;
     public static final int DEFAULT_NUMBER_OF_SHARDS = 3;
     public static final int DEFAULT_NUMBER_OF_REPLICAS = 2;

--- a/docs/api/latest.md
+++ b/docs/api/latest.md
@@ -1,4 +1,4 @@
-# API Docs - v2.0.0
+# API Docs - v2.1.0-SNAPSHOT
 
 ## Store
 
@@ -82,7 +82,7 @@
     <tr>
         <td style="vertical-align: top">index.type</td>
         <td style="vertical-align: top; word-wrap: break-word">The the type of the index.</td>
-        <td style="vertical-align: top">_doc</td>
+        <td style="vertical-align: top">empty</td>
         <td style="vertical-align: top">STRING</td>
         <td style="vertical-align: top">Yes</td>
         <td style="vertical-align: top">No</td>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <packaging>pom</packaging>
     <groupId>org.wso2.extension.siddhi.store.elasticsearch</groupId>
     <artifactId>siddhi-store-elasticsearch-parent</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <name>Siddhi Extension - Elasticsearch Store</name>
     <profiles>
         <profile>


### PR DESCRIPTION
## Purpose
This fixes following two issues:
1. https://github.com/siddhi-io/siddhi-store-elasticsearch/issues/22
2. https://github.com/siddhi-io/siddhi-store-elasticsearch/issues/24

In addition to this,
error log is printed (instead of debug log) when an `ElasticsearchStatusException` is thrown from `createIndex()` method in `ElasticsearchEventTable` class so that the user will get to know when index creation fails. 

## Approach
### Fix for #22 :
Removing `builder.startObject(indexType);` and its corresponding `builder.endObject();` from the `createIndex()` method in `ElasticsearchEventTable` class. 

### Improvement proposed to fix #24 :
Coming up with new annotation `TypeMappings`. Please refer example config below:
```
@Store(type="elasticsearch", @TypeMappings(requestTimestamp="date", latitude="geo_point", longitude="geo_point"), elasticsearch.member.list="http://localhost:9200",username="elastic", password="changeme", bulk.actions="10000", bulk.size="5")
define table ESTable (meta_clientType string, requestTimestamp long, latitude double, longitude double);
```
Here we can specify the list of type mappings. 
In this example config, 'requestTimestamp' attribute is mapped to type 'date', 'latitude' attribute is being mapped to type 'geo_point' and so on. 

## Release note
Introduce `TypeMappings` annotation.

## Documentation
TODO

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Migrations (if applicable)
TODO

## Test environment
- APIM Analytics v2.6.0
- elasticsearch v7.1.1