### PR TITLE
Add the improvements done in es-7.x.x branch

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.siddhi.extension.store.elasticsearch</groupId>
         <artifactId>siddhi-store-elasticsearch-parent</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>siddhi-store-elasticsearch</artifactId>

--- a/component/src/main/java/io/siddhi/extension/store/elasticsearch/ElasticsearchRecordIterator.java
+++ b/component/src/main/java/io/siddhi/extension/store/elasticsearch/ElasticsearchRecordIterator.java
@@ -44,13 +44,12 @@ public class ElasticsearchRecordIterator implements RecordIterator<Object[]> {
     private List<Attribute> attributes;
     private Iterator<SearchHit> elasticsearchHitsIterator;
 
-    public ElasticsearchRecordIterator(String indexName, String indexType, String queryString,
+    public ElasticsearchRecordIterator(String indexName, String queryString,
                                        RestHighLevelClient restHighLevelClient, List<Attribute> attributes)
             throws ElasticsearchServiceException {
         this.attributes = attributes;
         QueryBuilder queryBuilder = getQueryBuilder(queryString);
         SearchRequest searchRequest = new SearchRequest(indexName);
-        searchRequest.types(indexType);
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchSourceBuilder.query(queryBuilder);
         searchRequest.source(searchSourceBuilder);

--- a/component/src/main/java/io/siddhi/extension/store/elasticsearch/utils/ElasticsearchTableConstants.java
+++ b/component/src/main/java/io/siddhi/extension/store/elasticsearch/utils/ElasticsearchTableConstants.java
@@ -32,7 +32,6 @@ public class ElasticsearchTableConstants {
     public static final String ANNOTATION_ELEMENT_INDEX_NUMBER_OF_SHARDS = "index.number.of.shards";
     public static final String ANNOTATION_ELEMENT_INDEX_NUMBER_OF_REPLICAS = "index.number.of.replicas";
     public static final String ANNOTATION_ELEMENT_INDEX_ALIAS = "index.alias";
-    public static final String ANNOTATION_ELEMENT_INDEX_TYPE = "index.type";
     public static final String ANNOTATION_ELEMENT_UPDATE_BATCH_SIZE = "update.batch.size";
     public static final String ANNOTATION_ELEMENT_BULK_ACTIONS = "bulk.actions";
     public static final String ANNOTATION_ELEMENT_BULK_SIZE = "bulk.size";
@@ -47,9 +46,9 @@ public class ElasticsearchTableConstants {
     public static final String ANNOTATION_ELEMENT_TRUSRTSTORE_PASS = "trust.store.pass";
     public static final String ANNOTATION_ELEMENT_PAYLOAD_INDEX_OF_INDEX_NAME = "payload.index.of.index.name";
     public static final String ANNOTATION_ELEMENT_MEMBER_LIST = "elasticsearch.member.list";
+    public static final String ANNOTATION_TYPE_MAPPINGS = "TypeMappings";
 
     public static final String DEFAULT_HOSTNAME = "localhost";
-    public static final String DEFAULT_INDEX_TYPE = "_doc";
     public static final int DEFAULT_PORT = 9200;
     public static final int DEFAULT_NUMBER_OF_SHARDS = 3;
     public static final int DEFAULT_NUMBER_OF_REPLICAS = 2;

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <packaging>pom</packaging>
     <groupId>io.siddhi.extension.store.elasticsearch</groupId>
     <artifactId>siddhi-store-elasticsearch-parent</artifactId>
-    <version>3.0.1-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
     <name>Siddhi Extension - Elasticsearch Store</name>
     <profiles>
         <profile>


### PR DESCRIPTION
## Purpose
Add the improvements done in es-7.x.x branch.

This includes the changes done in PRs:
- https://github.com/siddhi-io/siddhi-store-elasticsearch/pull/25
- https://github.com/siddhi-io/siddhi-store-elasticsearch/pull/26

## Release note
In this release introduces a new annotation called TypeMappings. Please refer example config below:
```
@Store(type="elasticsearch", @TypeMappings(requestTimestamp="date", latitude="geo_point", longitude="geo_point"), elasticsearch.member.list="http://localhost:9200",username="elastic", password="changeme", bulk.actions="10000", bulk.size="5")
define table ESTable (meta_clientType string, requestTimestamp long, latitude double, longitude double);
```
Here we can specify the list of type mappings.
In this example config, 'requestTimestamp' attribute is mapped to type 'date', 'latitude' attribute is being mapped to type 'geo_point' and so on.

Note:
If above annotation is used then need to re-index all the existing data after updating the mapping type. Otherwise we would see the following warning in Kibana when we try to update the index pattern.
```
"Mapping conflict . A field is defined as several types (string, integer, etc) across the indices that match this pattern. You may still be able to use these conflict fields in parts of Kibana, but they will be unavailable for functions that require Kibana to know their type. Correcting this issue will require reindexing your data."
```

## Documentation
TODO

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
- https://github.com/siddhi-io/siddhi-store-elasticsearch/pull/25
- https://github.com/siddhi-io/siddhi-store-elasticsearch/pull/26

## Migrations
N/A